### PR TITLE
[Port from Java] Fix HTTP response processing for WWW-Authenticate headers

### DIFF
--- a/NGit.Test/NGit.Test.csproj
+++ b/NGit.Test/NGit.Test.csproj
@@ -46,6 +46,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NGit.Transport\HttpAuthTest.cs" />
     <Compile Include="NGit\AbbreviatedObjectIdTest.cs" />
     <Compile Include="NGit\ConfigTest.cs" />
     <Compile Include="NGit\ConstantsEncodingTest.cs" />

--- a/NGit.Test/NGit.Transport/HttpAuthTest.cs
+++ b/NGit.Test/NGit.Transport/HttpAuthTest.cs
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2013, Microsoft Corporation
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+using System;
+using System.Net;
+using NGit.Util;
+using NUnit.Framework;
+using Sharpen;
+
+namespace NGit.Transport
+{
+	[TestFixture]
+	public class HttpAuthTest
+	{
+		private const string digestHeader = "WWW-Authenticate: Digest qop=\"auth\",algorithm=MD5-sess,nonce=\"+Upgraded+v1b9...ba\",charset=utf-8,realm=\"Digest\"";
+
+		private const string basicHeader = "WWW-Authenticate: Basic realm=\"everyones.loves.git\"";
+
+		private const string ntlmHeader = "WWW-Authenticate: NTLM";
+
+		private const string bearerHeader = "WWW-Authenticate: Bearer";
+
+		private const string URL_SAMPLE = "http://everyones.loves.git/u/2";
+
+		private const string BASIC = "Basic";
+
+		private const string DIGEST = "Digest";
+
+		[Test]
+		public void TestHttpAuthScanResponse()
+		{
+			CheckResponse(new string[] { basicHeader }, BASIC);
+			CheckResponse(new string[] { digestHeader }, DIGEST);
+			CheckResponse(new string[] { basicHeader, digestHeader }, DIGEST);
+			CheckResponse(new string[] { digestHeader, basicHeader }, DIGEST);
+			CheckResponse(new string[] { ntlmHeader, basicHeader, digestHeader,
+					bearerHeader }, DIGEST);
+			CheckResponse(new string[] { ntlmHeader, basicHeader, bearerHeader },
+					BASIC);
+		}
+
+		private static void CheckResponse(string[] headers, string expectedAuthMethod)
+		{
+			AuthHeadersResponse response = new AuthHeadersResponse(headers);
+			HttpAuthMethod authMethod = HttpAuthMethod.ScanResponse(response);
+
+			Assert.AreEqual(expectedAuthMethod, GetAuthMethodName(authMethod),
+				"Wrong authentication method: expected " + expectedAuthMethod
+						+ ", but received " + GetAuthMethodName(authMethod));
+		}
+
+		private static string GetAuthMethodName(HttpAuthMethod authMethod)
+		{
+			return authMethod.GetType().Name;
+		}
+
+		private class AuthHeadersResponse : HttpURLConnection
+		{
+			private WebHeaderCollection headerFields = new WebHeaderCollection();
+
+			public AuthHeadersResponse(string[] authHeaders)
+				: base(new Uri(URL_SAMPLE), HttpSupport.ProxyFor(ProxySelector.GetDefault(), new Uri(URL_SAMPLE)))
+			{
+				ParseHeaders(authHeaders);
+			}
+
+			public override string GetHeaderField(string name)
+			{
+				var values = headerFields.GetValues(name);
+
+				return values != null && values.Length > 0 ? values.Last() : null;
+			}
+
+			public override WebHeaderCollection GetHeaders()
+			{
+				return headerFields;
+			}
+
+			private void ParseHeaders(string[] headers) {
+				foreach (string header in headers)
+				{
+					int i = header.IndexOf(':');
+
+					if (i < 0)
+						continue;
+
+					string key = header.Substring(0, i);
+					string value = header.Substring(i + 1).Trim();
+
+					headerFields.Add(key, value);
+				}
+			}
+		}
+	}
+}

--- a/Sharpen/Sharpen/HttpURLConnection.cs
+++ b/Sharpen/Sharpen/HttpURLConnection.cs
@@ -1,21 +1,21 @@
-// 
+//
 // HttpURLConnection.cs
-//  
+//
 // Author:
 //       Lluis Sanchez Gual <lluis@novell.com>
-// 
+//
 // Copyright (c) 2010 Novell, Inc (http://www.novell.com)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,36 +31,36 @@ namespace Sharpen
 	public class URLConnection
 	{
 	}
-	
+
 	public class HttpsURLConnection: HttpURLConnection
 	{
 		internal HttpsURLConnection (Uri uri, Proxy p): base (uri, p)
 		{
 		}
-		
+
 		internal void SetSSLSocketFactory (object factory)
 		{
 			// TODO
 		}
 	}
-	
+
 	public class HttpURLConnection: URLConnection
 	{
 		public const int HTTP_OK = 200;
 		public const int HTTP_NOT_FOUND = 404;
 		public const int HTTP_FORBIDDEN = 403;
 		public const int HTTP_UNAUTHORIZED = 401;
-		
+
 		HttpWebRequest request;
 		HttpWebResponse reqResponse;
 		Uri url;
-		
+
 		internal HttpURLConnection (Uri uri, Proxy p)
 		{
 			url = uri;
 			request = (HttpWebRequest) HttpWebRequest.Create (uri);
 		}
-		
+
 		HttpWebResponse Response {
 			get {
 				if (reqResponse == null)
@@ -82,7 +82,7 @@ namespace Sharpen
 				return reqResponse;
 			}
 		}
-		
+
 		public void SetUseCaches (bool u)
 		{
 			if (u)
@@ -90,37 +90,37 @@ namespace Sharpen
 			else
 				request.CachePolicy = new System.Net.Cache.RequestCachePolicy (System.Net.Cache.RequestCacheLevel.BypassCache);
 		}
-		
+
 		public void SetRequestMethod (string method)
 		{
 			request.Method = method;
 		}
-		
+
 		public string GetRequestMethod ()
 		{
 			return request.Method;
 		}
-		
+
 		public void SetInstanceFollowRedirects (bool redirects)
 		{
 			request.AllowAutoRedirect = redirects;
 		}
-		
+
 		public void SetDoOutput (bool dooutput)
 		{
 			// Not required?
 		}
-		
+
 		public void SetFixedLengthStreamingMode (int len)
 		{
 			request.SendChunked = false;
 		}
-		
+
 		public void SetChunkedStreamingMode (int n)
 		{
 			request.SendChunked = true;
 		}
-		
+
 		public void SetRequestProperty (string key, string value)
 		{
 			switch (key.ToLower ()) {
@@ -134,54 +134,59 @@ namespace Sharpen
 			default: request.Headers.Set (key, value); break;
 			}
 		}
-		
+
 		public string GetResponseMessage ()
 		{
 			return Response.StatusDescription;
 		}
-		
+
 		public void SetConnectTimeout (int ms)
 		{
 			if (ms == 0)
 				ms = -1;
 			request.Timeout = ms;
 		}
-		
+
 		public void SetReadTimeout (int ms)
 		{
 			// Not available
 		}
-		
+
 		public InputStream GetInputStream ()
 		{
 			return Response.GetResponseStream ();
 		}
-		
+
 		public OutputStream GetOutputStream ()
 		{
 			return request.GetRequestStream ();
 		}
-		
-		public string GetHeaderField (string header)
+
+		public virtual string GetHeaderField(string header)
 		{
-			return Response.GetResponseHeader (header);
+			return Response.GetResponseHeader(header);
 		}
-		
-		public string GetContentType ()
+
+		public virtual WebHeaderCollection GetHeaders()
+		{
+			return Response.Headers;
+		}
+
+		public string GetContentType()
 		{
 			return Response.ContentType;
 		}
-		
+
 		public int GetContentLength ()
 		{
 			return (int) Response.ContentLength;
 		}
-		
+
 		public int GetResponseCode ()
 		{
 			return (int) Response.StatusCode;
 		}
-		
+
 		public Uri GetURL ()
 		{
 			return url;


### PR DESCRIPTION
The original code was able to process only one WWW-Authenticate
header in an HTTP response, and if this header was not one of
two expected, authentication failed regardless of that there
could be other headers in the response.

All WWW-Authenticate headers in an HTTP response have to be
browsed to find one of supported, i.e. Basic or Digest.
By that if both are present, the Digest one should be used
as more preferable.

Bug 357719 - HTTP authentication fails when server returns multiple WWW-Authenticate headers

refs https://bugs.eclipse.org/bugs/show_bug.cgi?id=357719
https://git.eclipse.org/r/#/c/13285/

Fixes: http://teampulse.telerik.com/view#item/314090

ping @Icenium/core @Icenium/richclients 
